### PR TITLE
Add Contribution Guidelines & CoC v.01

### DIFF
--- a/content/code_of_conduct.md
+++ b/content/code_of_conduct.md
@@ -1,0 +1,119 @@
+# Code of Conduct
+
+As part of the open science community, we must promote and advocate inclusivity through a welcoming environment, giving voice to the under-represented and marginalized people, and creating means and tools in building up a healthy community. Understanding this assertion, this Code of Conduct is the expression of these values, and intend to foster a space of kindness, cooperation and empathy within this particular project and the 
+community itself.
+
+# Applicability and Scope
+
+This Code of Conduct is applicable to all of the community spaces, including public channels, private channel and conversations, both in the case of online and offline communications and contributions to the project. In the ase of the violation of the Code of Conduct, the project contributors and the community members, will have rights to reevaluate the situation and sanction or expell those who crated the discomfort and violation. 
+
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation, among others. 
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+We aim to create a weloming environment in which the members from any diverse background can interact in positive and affirming way. For that basis we follow the below goals throughout our interactions:
+
+* Using welcoming and inclusive language
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+  
+Examples of unacceptable behavior include:
+
+  
+* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, pregnancy status, veteran status, political affiliation, marital status, body size, age, race, national origin, ethnic origin, nationality, immigration status, language, religion or lack thereof, or other identity marker. This includes anti-Indigenous/Nativeness and anti-Blackness.
+* Unwelcome comments regarding a person's lifestyle choices and practices, including those related to food, health, parenting, relationships, drugs, and employment.
+* Deliberate misgendering, using inappropriate pronouns, or use of "dead" or rejected names.
+* Gratuitous or off-topic sexual images or behavior in spaces where they're not appropriate.
+* Physical contact and simulated physical contact (eg, textual descriptions like "hug" or "backrub") without consent or after a request to stop.
+* Threats of violence.
+* Incitement of violence towards any individual or group, including encouraging a person to commit suicide or to engage in self-harm.
+* Deliberate intimidation.
+* Stalking or following - online or in the physical world.
+* Harassing photography or recording, including logging online activity for harassment purposes.
+* Sustained disruption of discussion.
+* Unwelcome sexual attention.
+* Patterns of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others.
+* Continued one-on-one communication after requests to cease.
+* Deliberate "outing" of any aspect of a person's identity without their consent except as necessary to protect vulnerable people from intentional abuse.
+* Publication of non-harassing private communication, such as a physical or email address, without their explicit permission
+* Jokes that resemble the above, such as "hipster racism", still count as harassment even if meant satirically or ironically.
+* Trolling, insulting or derogatory comments, and personal or political attacks
+  
+
+If you have questions or concerns about these issues please feel free to contact [REQUIRES CONTACT POINTS] and share your opinions and suggestions.
+
+## Reporting
+
+
+If you are being harassed by a member of our community, notice that someone else is being harassed, or have any other concerns, please contact the administrators via  [REQUIRES CONTACT POINTS]. If the person who is harassing you is on the project collaborations team, they will not be involved in handling or resolving the incident.
+
+The admin team will respond to any complaint as promptly as possible we can. If you do not get a timely response (for example, if no admins are currently online) then please put your personal safety and well-being first, and consider logging out and/or contacting the admins by email at [EMAIL ADDRESS HERE].
+
+This Code of Conduct applies to our community's spaces, but if you are being harassed by a member of our community outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by our members, especially the administrators, seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from the community based on their past behavior, including behavior outside of our spaces and behavior towards people who are not in this community.
+
+In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response.
+
+
+## Enforcement Responsibilities
+
+The project leaders are responsible for clarifying and enforcing the standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+The project leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+
+## Enforcement
+
+Every code of conduct violation report will be treated with seriousness and care. If a member's immediate safety and security is threatened, an individual admin may take any action that they deem appropriate, up to and including temporarily banning the offender from the community. In less urgent situations, at least two admins will discuss the offense and mutually arrive at a suitable response, which will be shared with the offender privately. Whatever the resolution that they decide upon, the decision of the admins involved in a violation case will be considered final.
+
+We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we've received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of our members or the general public. We will not name harassment victims without their affirmative consent.
+
+
+## Enforcement Guidelines
+
+Community leaders will follow the Community Impact Guideline in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### Expulsion
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A ban from any sort of public interaction within the community and identification of the participant as a harasser to other members or to the general public.
+
+
+## Consequences
+
+Participants asked to stop any harassing behavior are expected to comply immediately. If a participant engages in harassing behavior, the administrators may take any action they deem appropriate, up to and including expulsion from the community and identification of the participant as a harasser to other members. At the discretion of the admins, or by request, one or more of the parties involved may request to discuss the violation and how to avoid similar situations in the future.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant Code of Conduct v2.0][contributorcovenant-coc], [LGBTQ in Tech community code of conduct](http://lgbtq.technology/coc.html). and from the [Django Project Code of Conduct][django-coc]. Community Impact Guideline were inspired by [Mozilla's code of conduct enforcement ladder][mozilla-coc]
+
+[contributorcovenant-coc]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[django-coc]: https://www.djangoproject.com/conduct/
+[mozilla-coc]: https://github.com/mozilla/diversity
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion)
+
+## License
+
+Community Covenant is licensed under a Creative Commons Attribution 4.0 International License (http://creativecommons.org/licenses/by/4.0/). Based on a work at http://community-covenant.net/.

--- a/content/contribution_guidelines.md
+++ b/content/contribution_guidelines.md
@@ -1,0 +1,253 @@
+# Contributing to the Neuroimaging Cookbook
+
+Welcome to the Neuroimaging Cookbook repository! In this project, contributions from the community are highly welcome. This guideline will give you all the necessary instructions to contribute to the Neuroimaging Cookbook, whether you are new to the whole workflow or not. 
+ 
+Please do not forget, you are welcome to contribute to the development of the BNeuroimaging Cookbook no matter your skill level or experiences. There is no single way of contributing to open science projects. Everyone from every level of skill and experience can make a huge impact on the development of the Neuroimaging Cookbook. And there is no “being ready-enough” to start contributing to an open science project. You might start contributing inside of your comfort zone, and with time, switch over the other parts. Contributing to an open science project is one of the most efficient ways of learning and improving your skill sets because it is a safe environment in which to make mistakes and engage with a collaborative community.
+
+As in many open science projects, you can contribute in many ways. You can write community documents and guidelines, test the code, collect case studies, provide feedback, address issues, or start coding small bits and pieces. All of these contributions are equally important. Therefore, please do not hesitate to offer your contributions! Open science tools can only grow with community support,  so any single intention of help is extremely appreciated.
+ 
+## Table of contents
+Been here before? Already know what you're looking for? Jump to the following sections:
+- _[Joining the Neuroimaging Cookbook Project](#joining_neuroimaging_cookbook_project)_
+- _[Code of Conduct](#code_of_conduct)_
+- _[Reach Us](#reach_us)_
+- _[Contributing through GitHub](#contributing_through_github)_
+- _[Where to start: wiki, code, and templates](#where_to_start)_
+- _[Make a change with a pull request](#make_changes_pull_request)_
+    - _Example pull request_
+- _[Recognizing contributions](#recognizing_contributions)_
+
+ 
+## [Joining the Neuroimaging Cookbook Project](#joining_neuroimaging_cookbook_project)
+[Neuroimaging Cookbook Project](https://github.com/neuroimaging-cookbook/neuroimaging-cookbook.github.io) is a community project, aims to centralize code snippets from different software languages to help the community with runing/initializing their neuroimaging analysis and provide them an easier and fluid experiences in adopting open science practices in coding that serves to the same analysis purposes.
+
+The best way to start contributing to an open science community and project is to actively engage with the community resources and platforms and contributing to the ongoing projects as much as you can contribute. To start your contributions to Neuroimaging Cookbook, you might begin with reviewing and working on the currently listed [issues](https://github.com/neuroimaging-cookbook/neuroimaging-cookbook.github.io/issues)in the Neuroimaging Cookbook repository and get involved in discussions run on the [Neuroimagign Cookbook communication channels](https://mattermost.brainhack.org/brainhack/channels/neuroimaging-cookbook). Before you start,   please make sure that you read our [Code of Conduct]( ) which aims to assure creating equal, safe, and fair opportunities for every single contributor to the project.
+ 
+## [Code of Conduct](#code_of_conduct)
+If you decide to contribute to the app’s development, we ask that you and all of our contributors read and adhere to our [Code of Conduct]()
+
+The [Code of Conduct]() aims to provide accessible, inclusive, diverse, and safe community environments so that every single contributor is equitably valued. We must ensure respect and safety to move the community forward. Therefore, we want to emphasize that all contributors and users must accept and follow our Code of Conduct. Please go through the Code of Conduct and make sure you follow each of the listed acts.
+
+## [Reach Us](#reach_us)
+There are lots of ways to get in touch with the team maintaining Neuroimaging Cookbook.
+
+- Our communication channel in the [Neuroimaging Cookbook Mattermost Team](https://mattermost.brainhack.org/brainhack/channels/neuroimaging-cookbook)
+This is our preferred way to answer questions so that others who have similar questions can benefit too! Even if your question is not well-defined, just post what you have so far and we will be able to point you in the right direction.
+
+
+- The Github Issues 
+[Neuroimaging Cookbook Issues](https://github.com/neuroimaging-cookbook/neuroimaging-cookbook.github.io/issues)
+
+
+## [Contributing through GitHub](#contributing_through_github)
+Before you start, you'll need to set up a free [GitHub](https://github.com/) account and sign in. Here are some [instructions](https://help.github.com/articles/signing-up-for-a-new-github-account). 
+
+[Git](https://git-scm.com/) is a version control tool, widely used by the open-source science community, which allows contributors to track changes and sync work with the master (main) repository. [GitHub](https://github.com/) sits on top of git and supports collaborative and distributed working.
+
+If you're not yet familiar with git, there are lots of great resources to help you git started! Some of our favourites include the [git Handbook](https://guides.github.com/introduction/git-handbook/) and the [Software Carpentry](http://swcarpentry.github.io/git-novice/) [introduction to git](http://swcarpentry.github.io/git-novice/). Also, our community is here to help you as necessary. Please do not hesitate to reach out with questions and requests for the support! We are here to help! ❤️
+ 
+## Writing in markdown
+GitHub has a helpful page on [getting started with writing and formatting on GitHub](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github). Most of the writing that you'll do will be in [Markdown](https://daringfireball.net/projects/markdown). You can think of Markdown as a few little symbols around your text that will allow GitHub to recognize and format the text. For example, you could write words as bold (`**bold**`)`, or in italics (``*italics*`), or as a link (`[link](https://https://youtu.be/dQw4w9WgXcQ)`) to another webpage.	
+
+
+## [Where to start: wiki, code, and templates](#where_to_start)
+
+
+### Wiki (link)
+The easiest place to find information about. Review the wiki to better understand Neuroimaging Cookbook, use cases, and areas of improvement. 
+
+### Code (link)
+Although the repository is under development, we hope that users and contributors can find and share small pieces of code that are useful for getting started with the app. To contribute to the codebase you'll need to submit a pull request. Check out our pull request guidelines below.
+ 
+### Issues
+Every project on GitHub uses a set of issues to publicly list and discuss standing problems and/or missing features in the current project and allows continuing discussions over public channels. Anyone with a Github account can contribute to these discussions and take a role in decisions. Issues cover many different aspects of the project. For instance, an issue might discuss the maintenance of a piece of code or a document,  it might introduce a new feature or update to bring to the project, or it might ask for help in addressing a problem with the project. Each of these issues has a set of goals and a timeline to move the project forward. By using issues, contributors can easily keep track of and address standing problems and see the assigned contributors and the urgency of the issue at hand. 
+ 
+Issues should be simple, short, and require one single task. Although it can be tempting to create a giant issue that requires many steps, splitting issues into smaller pieces increases readability and allows contributors from all possible backgrounds to participate. Smaller issues also promote fair division labour among contributors as well as make auditing and tracing the issue’s progress easier. 
+
+We use labels on our issues, which indicate how each issue relates to the overall project's goals and immediate next steps.
+ 
+### Issue Labels
+The current list of issue labels are here and include:
+[Neuroimaging Cookbook Issues](htps://github.com/neuroimaging-cookbook/neuroimaging-cookbook.github.io/issues)
+
+
+**good first issue** These issues contain tasks that are accessible to new contributors because they do not require advanced skills or a steep learning curve. If you're not sure about how to go about contributing, these are good places to start. You'll be mentored through the contribution process by the maintenance team. If you're a seasoned contributor, please select a different issue to work on and keep these available for the newer and potentially more anxious team members. If you feel that you can contribute to one of these issues, we especially encourage you to do so! 
+ 
+**bug** These issues point to problems in the project. If you find a new bug, please give as much detail as possible in your issue, including steps to recreate the error. If you experience the same bug as one already listed, please add any additional information that you have as a comment.
+ 
+**feature** These issues introduce new features and improvements for consideration. Please try to make sure that your requested feature is distinct from any others that have already been requested or implemented. If you find one that's similar but there are subtle differences, please reference the other request in your issue.
+ 
+**enhancement** These issues suggest new updates and amendments regarding an existing feature of the project. If you think there is a need for an enhancement in an existing feature due to the difficulties it creates in the current form, please give as much detail as possible about those difficulties. In addition, provide suggestions about potential methods/approaches to resolving those difficulties and the possible workload associated with the enhancement. 
+ 
+**question** It indicates that an issue or pull request needs more information. These issues ask questions about the project or point out areas that might need clarification and/or discussion. This label is usually used to resolve quick questions through contributor discussion in contrast to bigger issues that require resolving a bug or adding new features. Using this label will attract the contributors’ attention easily and will let them contribute to the discussions quickly. Similarly, if you see such a label on an issue, please do not hesitate to share your thoughts and suggestions. 
+ 
+**help wanted** It indicates a new feature, request, or enhancement. This label can include any change or upgrade that increases the project capabilities, performance, or scalability. In general, enhancements include:
+
+- Additional functionality
+- Error/bug repair and handling
+- Better code coverage
+- Improved performance
+ 
+**invalid** It indicates that an issue or pull request is no longer relevant.
+ 
+**dependencies** It helps to track and resolve vulnerabilities for certain types of dependencies.
+ 
+**wont fix** It indicates issues that are currently not viable to solve or out of the scope of the project
+ 
+**documentation** These issues relate to improving or updating the documentation.
+These are usually really great issues to help out with: the main goal of good documentation is to facilitate the contribution and use of the app without leaving any grey areas to the reader. Therefore any documents that would achieve this goal would be more than welcome!
+
+**community** These issues relate to building and supporting the app’s community. 
+
+
+Open science projects would not live without the support of the community. Any opportunity that would allow a contribution from the community should be listed as an issue and labelled with this particular label. 
+ 
+## [Make a change with a pull request](#make_changes_pull_request)
+We appreciate all contributions and pull requests to the Neuroimaging Cookbook from the community. **THANK YOU** for helping us build this useful resource. We recommend that you use this workflow when contributing to the Neuroimaging Cookbook:  
+ 
+**1. First, comment on an existing issue or open a new issue.**
+This allows other members of the BNeuroimaging Cookbook development team to confirm that you aren't overlapping with work that's already underway and that all contributors are operating with shared goals. [This blog](https://www.igvita.com/2011/12/19/dont-push-your-pull-requests) provides a nice explanation of why putting this work in upfront is so useful to everyone involved.
+
+**2. [Fork](https://help.github.com/articles/fork-a-repo) the related repository from the Neuroimaging Cookbook organization to your account**
+
+[Neuroimaging Cookbook Repository](htps://github.com/neuroimaging-cookbook/neuroimaging-cookbook.github.io/)
+
+
+Click on the ‘Fork’ button near the top of the page. This creates a copy of the code under your account on GitHub. For more details on how to fork a repository see this guide. This is now your own unique copy of the Neuroimaging Cookbook. Changes here won't affect anyone else's work, so it's a safe space to explore edits to the code!
+
+Make sure to [keep your fork up to date](https://help.github.com/articles/syncing-a-fork) with the master repository, otherwise, you can end up with lots of dreaded 
+[merge conflicts](https://help.github.com/articles/about-merge-conflicts).
+ 
+**3. [Clone](https://help.github.com/articles/cloning-a-repository) your forked Neuroimaging Cookbook repository to your machine/computer.**
+While you can edit files [directly on Github](https://help.github.com/articles/editing-files-in-your-repository), sometimes the changes you want to make will be complex and you will want to use a [text editor](https://en.wikipedia.org/wiki/Text_editor) that you have installed on your local machine/computer. 
+(One great text editor is [vscode](https://code.visualstudio.com/)). In order to work on the code locally, you must clone your forked repository. 
+To keep up with the changes in the Neuroimaging Cookbook, add the [Neuroimaging Cookbook](https://help.github.com/articles/configuring-a-remote-for-a-fork) as a remote to your locally cloned repository.
+
+**Neuroimaging Cookbook Repository**
+
+`git remote add upstream https://github.com/neuroimaging-cookbook/neuroimaging-cookbook.github.io/?`
+ 
+ 
+Make sure to [keep your fork up to date](https://help.github.com/articles/syncing-a-fork/) with the upstream repository.
+For example, to update your master branch on your local cloned repository:
+
+`git fetch upstream`
+`git checkout master`
+`git merge upstream/master`
+ 
+**4. Install the development dependencies:**
+ 
+**5. Synchronize your master branch with the upstream master branch:**
+`$ git checkout master`
+`$ git pull upstream master`
+ 
+**6. Create a [new branch](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/) to develop and maintain your proposed code changes.** 
+For example:
+`git fetch upstream` # Always start with an updated upstream
+`git checkout -b fix/bug-1222 upstream/master`
+
+and start making changes. Always use a feature branch. It’s good practice to never work on the `main` branch!
+
+Please consider using appropriate branch names as those listed below, and mind that some of them are special (e.g., doc/ and docs/):
+- fix/<some-identifier>: for bug fixes
+- enh/<feature-name>: for new features
+- doc/<some-identifier>: for documentation improvements. 
+
+You should name all your documentation branches with the prefix doc/ or docs/ as that will preempt triggering the full battery of continuous integration tests.
+ 
+ 
+**7. Make the changes you've discussed**
+Develop the feature on your feature branch on your computer, using Git to do the version control. When you’re done editing, add changed files using git add and then git commit:
+
+`$ git add modified_files`
+`$ git commit`
+
+to record your changes in Git, then push the changes to your GitHub account with:
+
+`$ git push -u origin my_feature`
+
+Try to keep the changes focused. It is generally easier to review changes that address one feature or bug at a time. It can also be helpful to test your changes locally, using a [REQUIRES INPUT]()
+
+Once you are satisfied with your local changes, [add/commit/push them](https://help.github.com/articles/adding-a-file-to-a-repository-using-the-command-line) to the branch on your forked repository. If you submit a large amount of work all in one go it will be much more work for whoever is reviewing your pull request. [Help them help you](https://media.giphy.com/media/uRb2p09vY8lEs/giphy.gif) 😉
+
+If you feel tempted to "branch out" then please make a [new branch](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository) and a [new issue](https://github.com/INCF/bids-starter-kit/issues) to go with it.
+ 
+**8. Submit [a pull request](https://help.github.com/articles/creating-a-pull-request)**
+Follow [these](https://help.github.com/articles/creating-a-pull-request-from-a-fork) instructions to create a pull request from your fork. This will send an email to the 
+committers. A member of the development team will review your changes to confirm that they can be merged into the main codebase.
+
+During a [review](https://help.github.com/articles/about-pull-request-reviews), the development team will probably ask a few questions to help clarify the work you've done. Keep an eye on your Github notifications and be prepared to join in that conversation.
+
+You can update your [fork](https://help.github.com/articles/fork-a-repo) of the Neuroimaging Cookbook repositories and the pull request will automatically update with those changes. You don't need to submit a new pull request when you make a change in response to questions/concerns that come up during a review.
+
+GitHub has a [nice introduction]https://guides.github.com/introduction/flow) to the pull request workflow, but please [get in touch](https://mattermost.brainhack.org/brainhack/channels/neuroimaging-cookbook) if you have any questions.
+
+## Pull Request Checklist
+Before a pull request (PR) can be merged, it needs to be approved by two core developers. Please prefix the title of your pull request with `[MRG]` if the contribution is complete and should be subjected to a detailed review. An incomplete contribution – where you expect to do more work before receiving a full review – should be prefixed `[WIP]` (to indicate a “work in progress”) and changed to `[MRG]` when it matures. WIPs may be useful to indicate you are working on something to avoid duplicated work, request a broad review of functionality or API, or seek collaborators. WIPs often benefit from the inclusion of a [task list](https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments) in the PR description.
+
+In order to ease the reviewing process, we recommend that your contribution complies with the following rules before marking a PR as `[MRG]`. The **bolded** ones are especially important:
+
+1. **Give your pull request a helpful title** that summarises what your contribution does. This title will often become the commit message once merged so it should summarise your contribution for posterity. In some cases “Fix <ISSUE TITLE>” is enough. “Fix #<ISSUE NUMBER>” is never a good title.
+
+2. **Make sure your code is properly commented and documented**, and **make sure the documentation renders properly**. 
+
+3.**Tests are necessary for enhancements to be accepted**. Bug-fixes or new features should be provided with [non-regression tests](https://en.wikipedia.org/wiki/Non-regression_testing). These tests verify the correct behaviour of the fix or feature. In this manner, further modifications on the codebase are granted to be consistent with the desired behaviour. In the case of bug fixes, at the time of the PR, the non-regression tests should fail for the codebase in the master branch and pass for the PR code.
+
+4. **Make sure that your PR does not add PEP8 violations**. To check the code that you changed, you can run the following command (see [above](https://scikit-learn.org/stable/developers/contributing.html#upstream) set up the upstream remote):
+`git diff upstream/master -u -- "*.py" | flake8 --diff`
+
+or `make flake8-diff` which should work on unix-like systems.
+
+5. Often pull requests resolve one or more other issues (or pull requests). If merging your pull request means that some other issues/PRs should be closed, you should [use keywords to create links to them](https://github.com/blog/1506-closing-issues-via-pull-requests/) (e.g., `Fixes #1234`; multiple issues/PRs are allowed as long as each one is preceded by a keyword). Upon merging, those issues/PRs will automatically be closed by GitHub. If your pull request is simply related to some other issues/PRs, create a link to them without using the keywords (e.g., `See also #1234`).
+
+6. PRs should often substantiate the change, through benchmarks of performance and efficiency or through examples of usage. Examples also illustrate the features and intricacies of the library to users.
+
+7. New features often need to be illustrated with narrative documentation in the user guide, with small code snippets. If relevant, please also add references in the literature, with PDF links when possible.
+
+8. The user guide should also include expected time and space complexity of the algorithm and scalability, e.g. “this algorithm can scale to a large number of samples > 100000, but does not scale in dimensionality: n_features is expected to be lower than 100”.
+
+9. Moderate use of type annotations is encouraged but is not mandatory. See [mypy quickstart](https://mypy.readthedocs.io/en/latest/getting_started.html) for an introduction, as well as [pandas contributing documentation]( https://pandas.pydata.org/pandas-docs/stable/development/contributing.html#type-hints) for style guidelines. 
+ 
+### Example pull request
+
+[IMAGE HERE]()
+
+
+ 
+A maintainer/developer will review and might suggest some changes before merging them into the repository.
+Success!! 🎉 Well done! 🙇‍♂️
+ 
+### Retrieving the latest code 
+We use [Git](http://git-scm.com/) for version control and [GitHub](https://github.com/) for hosting our main repository. If you are new on GitHub and don't know how to work with it, please first have a look at [this](https://try.github.io/) to get the basics.
+
+You can check out the latest sources with the command:
+`git clone git://github.com/?`
+
+or if you have write privileges:
+`git clone git@//github.com/?`
+
+### Installing the latest code
+In order to ensure that any code changes are reflected in your installation, navigate to 
+your cloned Nilearn base directory and install using the following command:
+`pip install -e .`
+ 
+ 
+## [Recognizing contributions](#recognizing_contributions)
+Neuroimaging Cookbook follows the [all-contributors](https://github.com/kentcdodds/all-contributors#emoji-key) specification, so we welcome and recognize all contributions from documentation to testing to code development. You can see a list of current contributors here.
+
+## [Get in Touch with us](#get_in_touch) 📬
+If you have any questions, comments, or suggestions, please feel free to create an issue in our repositories! A Maintainer or community member will follow up.
+
+If you'd prefer to email then you can contact [EMAIL]()
+Thank you!
+
+You're awesome. 👋😃
+References
+
+[ScikitLearn Contribution Guideline](https://scikit-learn.org/stable/developers/contributing.html#contributing-code)
+[Nilearn Contribution Guideline](https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst)
+[fMRIPrep Contribution Guideline](https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md)
+[BIDS App Contribution Guideline](https://github.com/BIDS-Apps/bids-apps.github.io/blob/master/CONTRIBUTING.md)
+[BIDS Starter KIT](https://github.com/bids-standard/bids-starter-kit/blob/master/CONTRIBUTING.md)
+
+


### PR DESCRIPTION
The first draft of the Contribution Guidelines and Code Of Conduct is added. 

Contribution Guidelines requires technical inputs to be added regarding setting up the environment at their local to contribute to the project and more. Please do have a look at them and let me know about the instructions to be added.  One of the examples for missing info (indicated with ?) could be for the instructions for forking and keeping update the fork with the upstream 

`git remote add upstream https://github.com/neuroimaging-cookbook/neuroimaging-cookbook.github.io/?`

Same ? is needed to be filled in many locations I believe they all should be the same but I was not able to know. Please do let me know about it I will add it to the necessary lines. 
 
Code of Conduct requires contact point and your approval regarding the context, reporting, enforcement. Please take both as the first draft and let me know how we could improve on those. 

Thank you 🤗 